### PR TITLE
Terminate the ephemeral docker daemon with a SIGTERM

### DIFF
--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -3,17 +3,18 @@
 
 import docker
 import functools
+import io
 import json
 import logging
 import mesos.interface
-import pesos.executor
 import os
+import pesos.executor
+import re
+import signal
+import subprocess
 import threading
 import time
-import re
-import subprocess
 import traceback
-import io
 
 from pesos.vendor.mesos import mesos_pb2
 


### PR DESCRIPTION
Due to a bug with using DockerInDocker (https://github.com/jpetazzo/dind/issues/19) it is important for us to terminate the ephemeral docker daemon running inside of our container with a SIGTERM. This should hopefully clean up lookback devices to avoid that issue.

This should be as simple as reliably calling `terminate()` on [proc](https://github.com/duedil-ltd/portainer/blob/master/portainer/app/executor.py#L72) when the executor chooses to die.
