### PR TITLE
Re-raise async exceptions to cause a build failure

### DIFF
--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -282,7 +282,6 @@ class Scheduler(mesos.interface.Scheduler):
                 logger.error("Caught exception uploading the context: %s" % e.message)
                 logger.error(traceback.format_exc(tb))
                 caught_exception.set()
-                raise e
 
             event = self.filesystem.setcontents_async(
                 path=staging_context_path,


### PR DESCRIPTION
If an exception is caught while uploading the build context it is logged but not re-raised. Because the upload happens in another thread, we need to capture this in the main thread and re-raise so the framework actually exists and carries the right status code.
