### PR TITLE
Clean up the staging directory after a build succeeds

### DIFF
--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -513,6 +513,8 @@ class TaskCleanupThread(threading.Thread):
             try:
                 if self.filesystem.isdir(staging_dir):
                     self.filesystem.removedir(staging_dir, force=True)
+                else:
+                    logger.info("Skipping cleanup of directory %s as it doesn't exist", staging_dir)
                 self._queue.task_done()
             except Exception, e:
                 logger.error("Caught exception cleaning staging directory %s (%s)", staging_dir, e)

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -52,7 +52,7 @@ class Scheduler(mesos.interface.Scheduler):
         self.failed = 0
         self.task_ids = {}
 
-        self.processing_offers = threading.Lock()
+        self._processing_offers = threading.Lock()
 
         # Ensure the staging directory exists
         self.filesystem = None
@@ -101,7 +101,7 @@ class Scheduler(mesos.interface.Scheduler):
     def _handle_offers(self, driver, offers):
 
         # We only want to process offers one set at a time
-        with self.processing_offers:
+        with self._processing_offers:
             tasks_to_launch = []
 
             if not self.pending:

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -202,13 +202,9 @@ class Scheduler(mesos.interface.Scheduler):
 
         finished = False
         failed = False
-        task_id = None
+        task_id = update.task_id.value
 
-        if update.task_id.value in self.task_ids:
-            build_task = self.task_ids[update.task_id.value]
-            task_id = build_task.image.repository
-        else:
-            task_id = update.task_id.value
+        if update.task_id.value not in self.task_ids:
             logger.error("Task update for unknown task! %s", task_id)
 
         if update.state == mesos_pb2.TASK_STARTING:
@@ -488,7 +484,7 @@ class TaskCleanupThread(threading.Thread):
 
         super(TaskCleanupThread, self).__init__(*args, **kwargs)
 
-        self.setDeemon(True)
+        self.setDaemon(True)
 
     def schedule_cleanup(self, task_id, attempt=0):
 


### PR DESCRIPTION
If the staging directory is used to host the build context for an image, when the build succeeds we should clean up the files automatically, and in the event of a failure, alert the user that the files were not cleaned up.