### PR TITLE
Upgrade pesos for mesos status ack fixes

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 git+git://github.com/duedil-ltd/tornado.git@1ceefdd89be8c3df217d79e0faa2d1948a231646#egg=tornado
 git+git://github.com/wickman/compactor.git@0a16c6f8af55171d46cc03d4abfa4e3d5ef8ea38#egg=compactor
-git+git://github.com/tarnfeld/pesos.git@f2a89b4576dc9435bbb82316f62e9b800d791c17#egg=pesos
+git+git://github.com/tarnfeld/pesos.git@51c49011e73036bcdbc6824ed526ddcc1f67bc8c#egg=pesos
 git+git://github.com/duedil-ltd/pyfilesystem.git@f952ec334e074d56f187dd61a3932d7b884dbdde#egg=fs
 trollius==0.4
 protobuf==2.5.0


### PR DESCRIPTION
This PR fixes an issue with status update acknowledgements in Mesos > 0.20.0. wickman/pesos#14

See https://issues.apache.org/jira/browse/MESOS-1409.