### PR TITLE
Support use with mesos native docker containerizer

### DIFF
--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -227,7 +227,7 @@ class Executor(mesos.interface.Executor):
                             str("%s: %s" % (image_name, message))
                         )
             else:
-                sandbox_dir = os.environ["MESOS_DIRECTORY"]
+                sandbox_dir = os.environ.get("MESOS_SANDBOX", os.environ["MESOS_DIRECTORY"])
                 context_path = os.path.join(sandbox_dir, buildTask.context)
 
                 if not os.path.exists(context_path):

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -353,9 +353,9 @@ class Scheduler(mesos.interface.Scheduler):
         )
 
         if self.container_image:
-            # TODO(tarnfeld): Support the mesos 0.20.0 docker protobuf too
-            task.executor.command.container.image = "docker://%s" % (self.container_image)
-            task.executor.command.container.options.extend(["--privileged"])
+            task.executor.container.type = mesos_pb2.ContainerInfo.DOCKER
+            task.executor.container.docker.image = self.container_image
+            task.executor.container.docker.privileged = True
 
         task.executor.name = "build"
         task.executor.source = "build %s" % (task.name)

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -348,7 +348,7 @@ class Scheduler(mesos.interface.Scheduler):
             args.append("--verbose")
 
         task.executor.executor_id.value = task_id
-        task.executor.command.value = "./%s/bin/portainer %s build-executor" % (
+        task.executor.command.value = "${MESOS_SANDBOX:-${MESOS_DIRECTORY}}/%s/bin/portainer %s build-executor" % (
             os.path.basename(self.executor_uri).rstrip(".tar.gz"), " ".join(args)
         )
 

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -190,7 +190,7 @@ class Scheduler(mesos.interface.Scheduler):
                         driver.stop()
                 else:
                     logger.info("Launching %d tasks", len(tasks))
-                    driver.launchTasks(offer.id, tasks)
+                    driver.launchTasks([offer.id], tasks)
 
     def status_update(self, driver, update):
         """Called when a status update is received from the mesos cluster."""

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,11 +1,9 @@
-git+git://github.com/duedil-ltd/tornado.git@1ceefdd89be8c3df217d79e0faa2d1948a231646#egg=tornado
-git+git://github.com/wickman/compactor.git@0a16c6f8af55171d46cc03d4abfa4e3d5ef8ea38#egg=compactor
-git+git://github.com/orls/pesos.git@7a46fb035cd902fb3b142cedf57de6aa4976a1f1#egg=pesos
+git+git://github.com/tarnfeld/pesos.git@d489a976cd9aaf9012e03888d7bfb44b903977c6#egg=pesos
 git+git://github.com/duedil-ltd/pyfilesystem.git@f952ec334e074d56f187dd61a3932d7b884dbdde#egg=fs
 trollius==0.4
-protobuf==2.5.0
+protobuf>=2.6.1,<2.7
 docker-py==0.4.0
 boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
-mesos.interface==0.21.0
+mesos.interface==0.21.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 git+git://github.com/duedil-ltd/tornado.git@1ceefdd89be8c3df217d79e0faa2d1948a231646#egg=tornado
 git+git://github.com/wickman/compactor.git@0a16c6f8af55171d46cc03d4abfa4e3d5ef8ea38#egg=compactor
-git+git://github.com/tarnfeld/pesos.git@f2a89b4576dc9435bbb82316f62e9b800d791c17#egg=pesos
+git+git://github.com/orls/pesos.git@7a46fb035cd902fb3b142cedf57de6aa4976a1f1#egg=pesos
 git+git://github.com/duedil-ltd/pyfilesystem.git@f952ec334e074d56f187dd61a3932d7b884dbdde#egg=fs
 trollius==0.4
 protobuf==2.5.0
@@ -8,4 +8,4 @@ docker-py==0.4.0
 boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
-mesos.interface==0.20.0
+mesos.interface==0.21.0


### PR DESCRIPTION
Send proper `ContainerInfo.DockerInfo` sub-message, instead of bundling all the docker info in the (old) `CommandInfo.ContainerInfo`

This involves some [dependency faff](https://github.com/orls/pesos/compare/786b578094e2281a688cc0fe00689876983ab4c3...protobufs-0-21) in pesos to get the protobuf definitions updated, so it operates off my own pesos `wip-branches` -- see the [diff from our previous locked version](https://github.com/orls/pesos/compare/f2a89b4576dc9435bbb82316f62e9b800d791c17...7a46fb035cd902fb3b142cedf57de6aa4976a1f1)