### PR TITLE
Fix not being able to use a remote docker daemon

### DIFF
--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -100,7 +100,7 @@ class Executor(mesos.interface.Executor):
             daemon_thread.setDaemon(True)
             daemon_thread.start()
         else:
-            self.docker = docker.Client(build_task.docker_host)
+            self.docker = docker.Client(build_task.daemon.docker_host)
             self.docker_daemon_up = True
 
     def disconnected(self, driver):


### PR DESCRIPTION
Looks like it was just a typo/oversight