### PR TITLE
Fix #22: escape unicode chars over the wire

### DIFF
--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -226,7 +226,7 @@ class Executor(mesos.interface.Executor):
                 for message, is_stream in self._wrap_docker_stream(build_request):
                     if not is_stream or (is_stream and buildTask.stream):
                         driver.sendFrameworkMessage(
-                            str("%s: %s" % (image_name, message))
+                            ("%s: %s" % (image_name, message)).encode('unicode-escape')
                         )
             else:
                 sandbox_dir = os.environ.get("MESOS_SANDBOX", os.environ["MESOS_DIRECTORY"])
@@ -246,7 +246,7 @@ class Executor(mesos.interface.Executor):
                     for message, is_stream in self._wrap_docker_stream(build_request):
                         if not is_stream or (is_stream and buildTask.stream):
                             driver.sendFrameworkMessage(
-                                str("%s: %s" % (image_name, message))
+                                ("%s: %s" % (image_name, message)).encode('unicode-escape')
                             )
 
             # Extract the newly created image ID

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -238,6 +238,7 @@ class Scheduler(mesos.interface.Scheduler):
             driver.stop()
 
     def framework_message(self, driver, executorId, slaveId, message):
+        message = message.decode('unicode-escape')
         if "Buffering" in message:  # Heh. This'll do for now, eh?
             logger.debug("\t%s", message)
         else:


### PR DESCRIPTION
Send docker output over the wire with unicode chars escaped, then unescape before printing.

There are unicode issues going deep into tornado, so this seems safest, if a bit brute-force