### PR TITLE
Automated squashing of built layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+notifications:
+  email: false
+language: python
+python:
+  - "2.7"
+cache: apt
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,14 @@ clean-env:
 protobuf: clean-proto
 	@echo "$(DOT) Building python proto modules."
 	protoc ./proto/*.proto --python_out=./portainer/
-	@echo "$(TICK) Building python proto modules."
+	@echo "$(TICK)  Building python proto modules."
 
 env:
 	@echo "$(DOT) Building virtual environment."
 	bin/setup
-	@echo "$(TICK) Finished setting up virtual environment."
+	@echo "$(TICK)  Finished setting up virtual environment."
+
+test:
+	@echo "$(DOT) Running tests."
+	bin/tests
+	@echo "$(TICK)  Tests passed!"

--- a/bin/tests
+++ b/bin/tests
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(dirname $(dirname "$0"))
+
+bin/setup
+source bin/env/bin/activate
+
+py.test portainer/

--- a/example/simple/Dockerfile
+++ b/example/simple/Dockerfile
@@ -1,0 +1,16 @@
+
+FROM busybox
+
+RUN echo 1 > /a
+RUN echo 2 > /b
+VOLUME /bar
+RUN mkdir /c && echo 3 > /c/a && echo 4 > /c/b
+RUN rm /bin/ls
+RUN rm /b
+EXPOSE 8080
+RUN rm /c/b
+VOLUME /baz
+EXPOSE 3000
+# RUN echo > /bin/hostname
+RUN rm /bin/ping
+# RUN rm /bin/hostname

--- a/example/simple/Dockerfile
+++ b/example/simple/Dockerfile
@@ -11,6 +11,5 @@ EXPOSE 8080
 RUN rm /c/b
 VOLUME /baz
 EXPOSE 3000
-# RUN echo > /bin/hostname
 RUN rm /bin/ping
-# RUN rm /bin/hostname
+RUN echo 3 > /b

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -42,6 +42,8 @@ def args(parser):
                        help="Docker image to run the portainer executor in")
     group.add_argument("--insecure", default=False, action="store_true",
                        help="Enable pulling/pushing of images with insecure registries")
+    group.add_argument("--squash", default=True, action="store_true",
+                       help="Squash the layers of the built image into a single one")
 
     # Arguments for the staging filesystem
     group = parser.add_argument_group("fs")
@@ -84,7 +86,8 @@ def main(args):
         stream=args.stream,
         docker_host=args.docker_host,
         verbose=args.verbose,
-        insecure_registries=args.insecure
+        insecure_registries=args.insecure,
+        squash_layers=args.squash
     )
 
     driver = pesos.scheduler.PesosSchedulerDriver(

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -42,7 +42,7 @@ def args(parser):
                        help="Docker image to run the portainer executor in")
     group.add_argument("--insecure", default=False, action="store_true",
                        help="Enable pulling/pushing of images with insecure registries")
-    group.add_argument("--squash", default=True, action="store_true",
+    group.add_argument("--squash", default=False, action="store_true",
                        help="Squash the layers of the built image into a single one")
 
     # Arguments for the staging filesystem

--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -331,8 +331,10 @@ class Executor(mesos.interface.Executor):
         driver.sendFrameworkMessage(str("%s: Squashing image" % image_name))
 
         # Figure out which layers need to be squashed
-        total_bytes, new_layers = get_squash_layers(self.docker, base_image_id, head_image_id)
-        total_mb = total_bytes / 1024 / 1024
+        base_image_id, head_image_id, total_bytes, new_layers = get_squash_layers(
+            self.docker, base_image_id, head_image_id
+        )
+        total_mb = total_bytes / 1024.0 / 1024.0
 
         driver.sendFrameworkMessage(str("%s:  ---> Squashing %d layers (%.2fMB)" % (image_name, len(new_layers), total_mb)))
 
@@ -359,7 +361,7 @@ class Executor(mesos.interface.Executor):
 
         # Generate a tarball of the final squashed layer
         driver.sendFrameworkMessage(str("%s:  ---> Creating tar for squashed layer" % image_name))
-        new_layer_tarball_path = generate_tarball(directory, working_dir)
+        new_layer_tarball_path = generate_tarball(sandbox_dir, working_dir)
 
         # Generate a tarball of the new layer that we can send to docker
         driver.sendFrameworkMessage(str("%s:  ---> Creating image tarball for image %s with parent %s" % (image_name, head_image_id[:12], base_image_id[:12])))

--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -24,6 +24,8 @@ from pesos.vendor.mesos import mesos_pb2
 
 from portainer.app import subcommand
 from portainer.proto import portainer_pb2
+from portainer.util.squash import get_squash_layers, download_layers_for_image, \
+    extract_layer_tar, apply_layer, generate_tarball, rewrite_image_parent
 
 
 logger = logging.getLogger("portainer.executor")

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -41,7 +41,7 @@ class Scheduler(mesos.interface.Scheduler):
     def __init__(self, tasks, executor_uri, cpu_limit, mem_limit, push_registry,
                  staging_uri, stream=False, verbose=False, repository=None,
                  pull_registry=None, docker_host=None, container_image=None,
-                 insecure_registries=False):
+                 insecure_registries=False, squash_layers=True):
 
         self.executor_uri = executor_uri
         self.cpu = float(cpu_limit)
@@ -55,6 +55,7 @@ class Scheduler(mesos.interface.Scheduler):
         self.docker_host = docker_host
         self.container_image = container_image
         self.insecure_registries = insecure_registries
+        self.squash_layers = squash_layers
 
         self.queued_tasks = []
         for path, tags in tasks:
@@ -260,6 +261,7 @@ class Scheduler(mesos.interface.Scheduler):
         # Define the build that's required
         build_task = portainer_pb2.BuildTask()
         build_task.stream = self.stream
+        build_task.squash = self.squash_layers
 
         # Create a custom docker context if there are local sources
         staging_context_path = None

--- a/portainer/proto/portainer_pb2.py
+++ b/portainer/proto/portainer_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='proto/portainer.proto',
   package='portainer',
-  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\x90\x01\n\tBuildTask\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
+  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\xa6\x01\n\tBuildTask\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\x12\x14\n\x06squash\x18\x08 \x01(\x08:\x04true\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
 
 
 
@@ -60,6 +60,13 @@ _BUILDTASK = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='squash', full_name='portainer.BuildTask.squash', index=5,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=True, default_value=True,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -70,7 +77,7 @@ _BUILDTASK = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=37,
-  serialized_end=181,
+  serialized_end=203,
 )
 
 
@@ -111,8 +118,8 @@ _DOCKERIMAGE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=183,
-  serialized_end=274,
+  serialized_start=205,
+  serialized_end=296,
 )
 
 
@@ -146,8 +153,8 @@ _DOCKERREGISTRY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=276,
-  serialized_end=328,
+  serialized_start=298,
+  serialized_end=350,
 )
 
 
@@ -188,8 +195,8 @@ _DOCKERDAEMON = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=330,
-  serialized_end=415,
+  serialized_start=352,
+  serialized_end=437,
 )
 
 _BUILDTASK.fields_by_name['image'].message_type = _DOCKERIMAGE

--- a/portainer/proto/portainer_pb2.py
+++ b/portainer/proto/portainer_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='proto/portainer.proto',
   package='portainer',
-  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\xa6\x01\n\tBuildTask\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\x12\x14\n\x06squash\x18\x08 \x01(\x08:\x04true\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
+  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\xa7\x01\n\tBuildTask\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\x12\x15\n\x06squash\x18\x08 \x01(\x08:\x05\x66\x61lse\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
 
 
 
@@ -63,7 +63,7 @@ _BUILDTASK = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='squash', full_name='portainer.BuildTask.squash', index=5,
       number=8, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=True,
+      has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -77,7 +77,7 @@ _BUILDTASK = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=37,
-  serialized_end=203,
+  serialized_end=204,
 )
 
 
@@ -118,8 +118,8 @@ _DOCKERIMAGE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=205,
-  serialized_end=296,
+  serialized_start=206,
+  serialized_end=297,
 )
 
 
@@ -153,8 +153,8 @@ _DOCKERREGISTRY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=298,
-  serialized_end=350,
+  serialized_start=299,
+  serialized_end=351,
 )
 
 
@@ -195,8 +195,8 @@ _DOCKERDAEMON = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=352,
-  serialized_end=437,
+  serialized_start=353,
+  serialized_end=438,
 )
 
 _BUILDTASK.fields_by_name['image'].message_type = _DOCKERIMAGE

--- a/portainer/util/fs.py
+++ b/portainer/util/fs.py
@@ -1,0 +1,24 @@
+
+import os.path
+import errno
+
+
+def touch(path, times=None):
+    """Mimics the behavior of the `touch` UNIX command line tool, to create
+    empty files.
+    """
+
+    with open(path):
+        os.utime(path, times)
+
+
+def mkdir_p(path):
+    """Mimics the behavior of the `mkdir -p` UNIX command line took, creating
+    directories recursively, ignoring them if they already exist.
+    """
+
+    try:
+        os.makedirs(path)
+    except OSError, e:
+        if e.errno != errno.EEXIST:
+            raise

--- a/portainer/util/fs.py
+++ b/portainer/util/fs.py
@@ -8,7 +8,7 @@ def touch(path, times=None):
     empty files.
     """
 
-    with open(path):
+    with open(path, "a"):
         os.utime(path, times)
 
 

--- a/portainer/util/squash.py
+++ b/portainer/util/squash.py
@@ -99,12 +99,14 @@ def apply_layer(directory, layer_tar, seen_paths=set()):
         if member.startswith(".wh..wh."):
             continue
         elif leaf.startswith(".wh."):
-            seen_paths.add(os.path.join(parent, leaf[4:]))
-            wh_path = os.path.join(directory, member)
-            wh_parent = os.path.dirname(wh_path)
-            if wh_parent != directory:
-                mkdir_p(wh_parent)
-            touch(wh_path)
+            name = os.path.join(parent, leaf[4:])
+            if name not in seen_paths:
+                seen_paths.add(name)
+                wh_path = os.path.join(directory, member)
+                wh_parent = os.path.dirname(wh_path)
+                if wh_parent != directory:
+                    mkdir_p(wh_parent)
+                touch(wh_path)
         elif member not in seen_paths:
             layer_tar.extract(member=member, path=directory)
             seen_paths.add(member)

--- a/portainer/util/squash.py
+++ b/portainer/util/squash.py
@@ -1,0 +1,134 @@
+
+import json
+import tempfile
+import os
+
+
+def get_squash_layers(docker, base_image_id, head_image_id):
+    """
+    get_squash_layers will return an ordered list of layers since `base_image_id`
+    that should be squashed together to form `head_image_id`. For example;
+
+    [A] -> [B] -> [C] -> [D]
+
+    get_squash_layers(base = A, head = D)
+        would return [D, C, B]
+
+    The function will return a tuple, where the first item is the size of all
+    layers (in bytes) and the second is the ordered list of layers.
+    """
+
+    # Pull out the full image IDs from the docker API
+    head_image_id = docker.inspect_image(head_image_id)["Id"]
+    base_image_id = docker.inspect_image(base_image_id)["Id"]
+
+    layers = []
+    aggregate_size = 0
+
+    for layer in json.loads(docker.history(head_image_id)):
+        if layer["Id"] == base_image_id:
+            break
+        layers.append(layer["Id"])
+        aggregate_size += layer["Size"]
+
+    return aggregate_size, layers
+
+
+def download_layers_for_image(docker, directory, image_id):
+    """
+    download_layers_for_image downloads all layers for `image_id` from docker
+    into a temporary file within `directory` and returns a file handle
+    to the tar.
+
+    The temporary file will be deleted once the file handle is closed.
+    """
+
+    _, path = tempfile.mkstemp(dir=directory, suffix=".tar")
+    fh = open(path, "wb+")
+    for chunk in docker.get_image(image_id).stream():
+        fh.write(chunk)
+
+    fh.seek(0)
+    return fh
+
+
+def extract_layer_tar(directory, layers_tar, layer_id):
+    """
+    extract_layer_tar will return an open file handle for the given to a tar
+    for the given `layer_id` after extracting it from the given `layers_tar`
+    TarFile.
+
+    When exporting an image from docker, it will provide a tar of each layer
+    that makes up the image.
+
+    Each layer will be in a folder (with the layer_id as the folder name) and the
+    filesystem for that layer will be within another tar. This function will take
+    care of locating this nested tar, and extracting it to somewhere temporary.
+    """
+
+    layer_member = os.path.join(layer_id, "layer.tar")
+    path = tempfile.mkdtemp(dir=directory)
+
+    layers_tar.extract(
+        member=layer_member,
+        path=path
+    )
+
+    return open(path, "wb+")
+
+
+def apply_layer(directory, layer_tar, seen_paths=set()):
+    """
+    apply_layer will apply the given `layer_tar` filesystem over the top of the
+    given `directory` correctly handling whiteouts based on the paths
+    that have already been seen by previous layers.
+    """
+
+    for member in layer_tar.members():
+        parent, leaf = os.path.split(member)
+        if member.startswith(".wh..wh."):
+            continue
+        elif leaf.startswith(".wh."):
+            seen_paths.add(os.path.join(parent, leaf[4:]))
+            try:
+                os.makedirs(
+                    os.path.dirname(os.path.join(directory, member))
+                )
+            except:
+                pass
+            with open(os.path.join(directory, member), "wb") as fh:
+                fh.write("")
+        elif member not in seen_paths:
+            layer.extract(member=member, path=directory)
+            seen_paths.add(member)
+
+    return seen_paths
+
+
+def generate_tarball(directory, tar_directory):
+    """
+    generate_tarball will return a path to a newly generated tarball inside the
+    given `directory`, with all of the contents of `tar_directory` within.
+    """
+
+    _, tarball_path = tempfile.mkstemp(dir=directory, suffix=".tar")
+    tarball = tarfile.open(tarball_path, "w")
+
+    for path in os.listdir(tar_directory):
+        tarball.add(os.path.join(tar_directory, path), arcname=path)
+
+    tarball.close()
+    return tarball_path
+
+
+def rewrite_image_parent(image_info, new_parent):
+    """
+    rewrite_image_parent will change the given image info dictionary to point
+    to the `new_parent` image.
+    """
+
+    image_info["parent"] = new_parent
+    image_info["config"]["Image"] = new_parent
+    image_info["container_config"]["Image"] = new_parent
+
+    return image_info

--- a/portainer/util/squash.py
+++ b/portainer/util/squash.py
@@ -6,22 +6,26 @@ import os
 
 def get_squash_layers(docker, base_image_id, head_image_id):
     """
-    get_squash_layers will return an ordered list of layers since `base_image_id`
-    that should be squashed together to form `head_image_id`. For example;
+    get_squash_layers will return an ordered list of the layers between `base_image_id`
+    and `head_image_id`, including `head_image_id`. This list can be used to determine
+    the layers that should be squashed together. For example, given this image
+    lineage;
 
-    [A] -> [B] -> [C] -> [D]
+    [A] <- [B] <- [C] <- [D]
 
-    get_squash_layers(base = A, head = D)
-        would return [D, C, B]
+    get_squash_layers(base = A, head = D) would return [D, C, B]
 
     The function will return a tuple of the following items;
-         - Base Image ID
-         - Head Image ID
-         - Size of all layers in bytes
-         - Ordered list of layers (top-down)
+     - Base Image ID
+     - Head Image ID
+     - Size of all layers in bytes
+     - Ordered list of layers (top-down)
     """
 
-    # Pull out the full image IDs from the docker API
+    # Pull out the full image IDs from the docker API, we might be given
+    # short hashes so we need to be sure we have the full ones. This also
+    # serves as a nice check to be sure the images exist in the docker
+    # daemon.
     head_image_id = docker.inspect_image(head_image_id)["Id"]
     base_image_id = docker.inspect_image(base_image_id)["Id"]
 

--- a/portainer/util/squash.py
+++ b/portainer/util/squash.py
@@ -3,6 +3,8 @@ import json
 import tempfile
 import os
 
+from .fs import touch, mkdir_p
+
 
 def get_squash_layers(docker, base_image_id, head_image_id):
     """
@@ -93,18 +95,16 @@ def apply_layer(directory, layer_tar, seen_paths=set()):
 
     for member in layer_tar.getnames():
         parent, leaf = os.path.split(member)
+
         if member.startswith(".wh..wh."):
             continue
         elif leaf.startswith(".wh."):
             seen_paths.add(os.path.join(parent, leaf[4:]))
-            try:
-                os.makedirs(
-                    os.path.dirname(os.path.join(directory, member))
-                )
-            except:
-                pass
-            with open(os.path.join(directory, member), "wb") as fh:
-                fh.write("")
+            wh_path = os.path.join(directory, member)
+            wh_parent = os.path.dirname(wh_path)
+            if wh_parent != directory:
+                mkdir_p(wh_parent)
+            touch(wh_path)
         elif member not in seen_paths:
             layer_tar.extract(member=member, path=directory)
             seen_paths.add(member)

--- a/portainer/util/test_squash.py
+++ b/portainer/util/test_squash.py
@@ -1,0 +1,40 @@
+import json
+import unittest
+from mock import patch
+
+from .squash import get_squash_layers
+
+
+@patch('docker.client.Client')
+class SquashLayersTestCase(unittest.TestCase):
+
+    def test_get_squash_layers_bottom(self, docker):
+        self._mock_squash(docker, "A", "A", ["_A"])
+
+    def test_get_squash_layers_direct_parent(self, docker):
+        self._mock_squash(docker, "A", "B", ["_B", "_A"])
+
+    def test_get_squash_layers_many(self, docker):
+        self._mock_squash(docker, "A", "D", ["_D", "_C", "_B", "_A"])
+
+    def _mock_squash(self, docker, base_image, head_image, lineage):
+
+        docker.inspect_image.side_effect = lambda id: {
+            "Id": "_%s" % id
+        }
+
+        docker.history.return_value = json.dumps([
+            {
+                "Id": id,
+                "Size": 1024
+            } for id in lineage
+        ])
+
+        new_base_image, new_head_image, size, layers = get_squash_layers(
+            docker, base_image, head_image
+        )
+
+        self.assertEqual(new_base_image, "_%s" % base_image)
+        self.assertEqual(new_head_image, "_%s" % head_image)
+        self.assertEqual(size, 1024 * (len(lineage) - 1))
+        self.assertListEqual(layers, lineage[:-1])

--- a/portainer/util/test_squash.py
+++ b/portainer/util/test_squash.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from mock import patch
 
-from .squash import get_squash_layers, download_layers_for_image
+from .squash import get_squash_layers, download_layers_for_image, extract_layer_tar
 
 
 @patch('docker.client.Client')
@@ -57,3 +57,19 @@ class DownloadImageLayersTestCase(unittest.TestCase):
         self.assertEqual(fh.read(1), "")
 
         fh.close()
+
+
+@patch('tarfile.TarFile')
+class LayerExctractionFromTarTestCase(unittest.TestCase):
+
+    @patch('portainer.util.squash.tempfile.mkdtemp', return_value="/tmp/path")
+    @patch('portainer.util.squash.open', return_value='fh')
+    def test_extraction(self, tempfile, tarfile, mock_open):
+
+        tar_fh = extract_layer_tar('/tmp', tarfile, 'A')
+        self.assertEqual(tar_fh, 'fh')
+
+        tarfile.extract.assert_called_with(
+            member='A/layer.tar',
+            path='/tmp/path'
+        )

--- a/portainer/util/test_squash.py
+++ b/portainer/util/test_squash.py
@@ -6,7 +6,7 @@ from cStringIO import StringIO
 from mock import patch, MagicMock
 
 from .squash import get_squash_layers, download_layers_for_image, \
-    extract_layer_tar, apply_layer
+    extract_layer_tar, apply_layer, rewrite_image_parent
 
 
 @patch('docker.client.Client')
@@ -262,3 +262,22 @@ class ApplyLayerTestCase(unittest.TestCase):
             new_dirs,
             seen_paths
         )
+
+
+class RewriteImageParentTestCase(unittest.TestCase):
+
+    def test_rewrite_parent(self):
+
+        self.assertDictEqual(rewrite_image_parent({
+            "parent": None,
+            "config": {},
+            "container_config": {}
+        }, "A"), {
+            "parent": "A",
+            "config": {
+                "Image": "A"
+            },
+            "container_config": {
+                "Image": "A"
+            }
+        })

--- a/proto/portainer.proto
+++ b/proto/portainer.proto
@@ -13,7 +13,7 @@ message BuildTask {
     optional string context = 2;
     optional string dockerfile = 6; // Optional string representation of the Dockerfile to build
     optional bool stream = 5; // Should we stream the build output?
-    optional bool squash = 8 [default=true]; // Squash the image into a single layer?
+    optional bool squash = 8 [default=false]; // Squash the image into a single layer?
 }
 
 /**

--- a/proto/portainer.proto
+++ b/proto/portainer.proto
@@ -13,6 +13,7 @@ message BuildTask {
     optional string context = 2;
     optional string dockerfile = 6; // Optional string representation of the Dockerfile to build
     optional bool stream = 5; // Should we stream the build output?
+    optional bool squash = 8 [default=true]; // Squash the image into a single layer?
 }
 
 /**

--- a/requirements.pip
+++ b/requirements.pip
@@ -7,3 +7,5 @@ boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
 mesos.interface==0.21.1
+mock==1.3.0
+pytest==2.8.0


### PR DESCRIPTION
This is an implementation of #25. This branch introduces a new command line argument (and proto flag) to enable squashing all the new layers from a build into a single one. It's kind-of based around the implementation of squashing by @jwilder (https://github.com/jwilder/docker-squash) but we've taken a different route to the squashing (working from the top layer first).

This should be pretty much in working order, and I've tried to cover as many different basic filesystem changes over multiple layers as I could think of, but if you have more to suggest to ensure the squashing is robust, please do!

```
...
2015-09-10 21:46:48,674[portainer.scheduler] Base requirements installed.
2015-09-10 21:46:49,497[portainer.scheduler]  ---> 46cea7929e36
2015-09-10 21:46:49,498[portainer.scheduler] Successfully built 46cea7929e36
2015-09-10 21:46:49,499[portainer.scheduler] Squashing image
2015-09-10 21:46:49,745[portainer.scheduler]  ---> Squashing 7 layers (213.35MB)
2015-09-10 21:46:49,746[portainer.scheduler]  ---> Exporting image from docker daemon
2015-09-10 21:46:52,708[portainer.scheduler]  ---> Extracting layer 46cea7929e36
2015-09-10 21:46:52,780[portainer.scheduler]      -> Squashing layer 46cea7929e36
...
2015-09-10 21:47:05,673[portainer.scheduler]  ---> Creating tar for squashed layer
2015-09-10 21:47:09,820[portainer.scheduler]  ---> Creating image tarball for image 46cea7929e36 with parent 57bca5139a13
2015-09-10 21:47:57,168[portainer.scheduler]  ---> Uploading squashed image to docker
2015-09-10 21:48:04,279[portainer.scheduler] Tagging image 46cea7929e364ec84c319327a0ccb417ccd954b9721c71ddbf3f4966fa7cb78a
2015-09-10 21:48:04,280[portainer.scheduler]    -> latest
2015-09-10 21:48:04,281[portainer.scheduler] Pushing image
...
```