### PR TITLE
Refactor build context prep to outside the scheduler loop

### DIFF
--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -72,7 +72,6 @@ def main(args):
         args.container_image = None
 
     scheduler = Scheduler(
-        tasks=[(d, args.tags) for d in args.dockerfile],
         executor_uri=args.executor,
         cpu_limit=args.build_cpu,
         mem_limit=args.build_mem,
@@ -95,6 +94,11 @@ def main(args):
     thread = threading.Thread(target=driver.run)
     thread.setDaemon(True)
     thread.start()
+
+    # Enqueue all of the dockerfiles we've been given via the command line to
+    # be built
+    for d in args.dockerfile:
+        scheduler.enqueue_build(d, args.tags)
 
     # Wait here until the tasks are done
     while thread.isAlive():

--- a/portainer/proto/portainer_pb2.py
+++ b/portainer/proto/portainer_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='proto/portainer.proto',
   package='portainer',
-  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\x90\x01\n\tBuildTask\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
+  serialized_pb='\n\x15proto/portainer.proto\x12\tportainer\"\xb6\x01\n\tBuildTask\x12\x0f\n\x07task_id\x18\x08 \x02(\t\x12%\n\x05image\x18\x01 \x02(\x0b\x32\x16.portainer.DockerImage\x12\'\n\x06\x64\x61\x65mon\x18\x07 \x01(\x0b\x32\x17.portainer.DockerDaemon\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12\x13\n\x0b\x63ontext_url\x18\t \x01(\t\x12\x12\n\ndockerfile\x18\x06 \x01(\t\x12\x0e\n\x06stream\x18\x05 \x01(\x08\"[\n\x0b\x44ockerImage\x12+\n\x08registry\x18\x02 \x01(\x0b\x32\x19.portainer.DockerRegistry\x12\x12\n\nrepository\x18\x01 \x02(\t\x12\x0b\n\x03tag\x18\x03 \x03(\t\"4\n\x0e\x44ockerRegistry\x12\x10\n\x08hostname\x18\x01 \x02(\t\x12\x10\n\x04port\x18\x02 \x01(\r:\x02\x38\x30\"U\n\x0c\x44ockerDaemon\x12\x13\n\x0b\x64ocker_host\x18\x01 \x01(\t\x12\x13\n\x0b\x64ocker_args\x18\x02 \x01(\t\x12\x1b\n\x13insecure_registries\x18\x03 \x03(\t')
 
 
 
@@ -26,35 +26,49 @@ _BUILDTASK = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='image', full_name='portainer.BuildTask.image', index=0,
+      name='task_id', full_name='portainer.BuildTask.task_id', index=0,
+      number=8, type=9, cpp_type=9, label=2,
+      has_default_value=False, default_value=unicode("", "utf-8"),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='image', full_name='portainer.BuildTask.image', index=1,
       number=1, type=11, cpp_type=10, label=2,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='daemon', full_name='portainer.BuildTask.daemon', index=1,
+      name='daemon', full_name='portainer.BuildTask.daemon', index=2,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='context', full_name='portainer.BuildTask.context', index=2,
+      name='context', full_name='portainer.BuildTask.context', index=3,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=unicode("", "utf-8"),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dockerfile', full_name='portainer.BuildTask.dockerfile', index=3,
+      name='context_url', full_name='portainer.BuildTask.context_url', index=4,
+      number=9, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=unicode("", "utf-8"),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='dockerfile', full_name='portainer.BuildTask.dockerfile', index=5,
       number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=unicode("", "utf-8"),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='stream', full_name='portainer.BuildTask.stream', index=4,
+      name='stream', full_name='portainer.BuildTask.stream', index=6,
       number=5, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -70,7 +84,7 @@ _BUILDTASK = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=37,
-  serialized_end=181,
+  serialized_end=219,
 )
 
 
@@ -111,8 +125,8 @@ _DOCKERIMAGE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=183,
-  serialized_end=274,
+  serialized_start=221,
+  serialized_end=312,
 )
 
 
@@ -146,8 +160,8 @@ _DOCKERREGISTRY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=276,
-  serialized_end=328,
+  serialized_start=314,
+  serialized_end=366,
 )
 
 
@@ -188,8 +202,8 @@ _DOCKERDAEMON = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=330,
-  serialized_end=415,
+  serialized_start=368,
+  serialized_end=453,
 )
 
 _BUILDTASK.fields_by_name['image'].message_type = _DOCKERIMAGE

--- a/proto/portainer.proto
+++ b/proto/portainer.proto
@@ -7,10 +7,15 @@ package portainer;
  *   context: Path to the build context tar file (relative to the task sandbox)
  */
 message BuildTask {
+    optional string task_id = 8; // This is optional for backwards compat.
     required DockerImage image = 1;
     optional DockerDaemon daemon = 7;
 
-    optional string context = 2;
+    // Note: I'd rather have put this within a nested structure (maybe a DockerContext)
+    // message but this makes for easier backwards compat.
+    optional string context = 2; // Filename of the custom build context
+    optional string context_url = 9; // Fully qualified URL to download the context
+
     optional string dockerfile = 6; // Optional string representation of the Dockerfile to build
     optional bool stream = 5; // Should we stream the build output?
 }


### PR DESCRIPTION
Previously al the build context prep (tarring it up, uploading it to the filesystem) was done after all the offers had been accepted, so if the prep took a while the offer would be hoarded. This isn't ideal as it can slow down the general speed of offer responses in the cluster.

I've refactored this so that the context is prepared before the task is put into the scheduler queue, so until that point offers will just be declined.

Also improved the exception handling inside some of callbacks to sort out a few niggles.