### PR TITLE
Don't mark a build as failed until it's actually terminal

### DIFF
--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -340,13 +340,13 @@ class Scheduler(mesos.interface.Scheduler):
             self.finished += 1
         elif failed:
             self.running -= 1
-            self.failed += 1
 
             # Re-queue the task if it hasn't started RUNNING yet
             if last_known_state in {None, mesos_pb2.TASK_STARTING, mesos_pb2.TASK_STAGING} and \
                self.task_retries[task_id] < self.max_retries:
                     self._reschedule_task(task_id, blacklist_slave=update.slave_id.value)
             else:
+                self.failed += 1
                 self.cleanup.schedule_cleanup(task_id)
 
         # If there are no tasks running, and the queue is empty, we should stop


### PR DESCRIPTION
If a build fails and is retried, the failed counter is incremented up by 1. This means that when you build an image and it is re-scheduled, even if it then succeeds the failed counter is aware of the failure.

Currently the logic to exit the `build` subcommand non-zero is based on whether `failed > 0` which means that we can exit non-zero for a successful build. This change only increments the counter once the build is actually terminal.
