### PR TITLE
[DD-13627] Upgrade Portainer to work with Mesos 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+notifications:
+  email: false
+language: python
+python:
+  - "2.7"
+cache: apt
+script: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # portainer source installed into /opt/portainer.
 #
 
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 MAINTAINER Oli Hall <oliver.hall@duedil.com>
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 FROM ubuntu:12.04
-MAINTAINER Tom Arnfeld <tom@duedil.com>
+MAINTAINER Oli Hall <oliver.hall@duedil.com>
 
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git python-setuptools python-virtualenv

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See below for more documentation on how to use the Vagrant virtual machine.
 
 #### Notes
 
-- Pushing built images to the public Docker index is currently not supported
+- Pushing built images to the public Docker index is currently not supported.
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Portainer
 
-Portainer is an [Apache Mesos](https://mesos.apache.org) framework that enables you to build docker images across a cluster of many machines.
+Portainer is an [Apache Mesos](https://mesos.apache.org) framework that enables you to build Docker images across a cluster of many machines.
 
 ```
                    .,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.
@@ -23,7 +23,7 @@ Portainer is an [Apache Mesos](https://mesos.apache.org) framework that enables 
            ```````
 ```
 
-When building docker images at scale, it can be time consuming and wasteful to manage dedicated infrastructure for building and pushing images. Building large containers with many sources and dependencies is a heavy operation, sometimes requiring many large machines. Deploying this infrastructure can be expensive and often leads to poor utilization.
+When building Docker images at scale, it can be time consuming and wasteful to manage dedicated infrastructure for building and pushing images. Building large containers with many sources and dependencies is a heavy operation, sometimes requiring many large machines. Deploying this infrastructure can be expensive and often leads to poor utilization.
 
 Given an existing Apache Mesos cluster, Portainer can get to work right away. If you're new to Mesos, you can try out the Vagrant box provided, or learn more about the [Apache Mesos Architecture](https://mesos.apache.org/documentation/latest/mesos-architecture/) and [get started](https://mesos.apache.org/gettingstarted/).
 
@@ -41,8 +41,7 @@ See below for more documentation on how to use the Vagrant virtual machine.
 
 #### Notes
 
-- Pushing built images to the public docker index is currently not supported
-- Support for docker client ~>1.7.0 requires Apache Mesos >=0.23.0 ([MESOS-3279](https://issues.apache.org/jira/browse/MESOS-3279))
+- Pushing built images to the public Docker index is currently not supported
 
 --------------------------------------------------------------------------------
 
@@ -59,7 +58,7 @@ You'll need to have the following dependencies installed to run the framework.
 
 ### Mesos Agent Dependencies
 
-By default, Portainer will try and launch an ephemeral docker daemon (`docker -d`) on the mesos agent machine using [docker in docker](https://github.com/jpetazzo/dind). This requires that you're using a Docker Containerizer on your Mesos agents. If you are not, you'll need to specify the `--docker-host` argument (e.g `--docker-host /var/run/docker.sock`) describing where the docker daemon can be accessed on each agent.
+By default, Portainer will try and launch an ephemeral Docker daemon (`docker -d`) on the mesos agent machine using [docker in docker](https://github.com/jpetazzo/dind). This requires that you're using a Docker Containerizer on your Mesos agents. If you are not, you'll need to specify the `--docker-host` argument (e.g `--docker-host /var/run/docker.sock`) describing where the Docker daemon can be accessed on each agent.
 
 ## Building an Image
 
@@ -69,13 +68,15 @@ By default, Portainer will try and launch an ephemeral docker daemon (`docker -d
 $ bin/build-executor
 ```
 
+This script uses PEX to package portainer's code into an executable to be run on Mesos.
+
 _Note: If you've got a dirty git tree, you'll need to set the `FORCE=1` environment variable._
 
 The built PEX (python executable) archive will be dumped into `./dist`, and needs to be uploaded somewhere Mesos can reach it (HDFS, S3, FTP, HTTP etc). Check the output from the build-executor command to see the file name, and upload the file.
 
 The environment name is tacked on to the archive filename, e.g. `dist/portainer-37cc6d5eb334473fdaa9c7522c4ce585032dca5c.linux-x86_64.tar.gz`. Make sure you build the executor on the same platform as your mesos slaves use.
 
-In future, readily-downloadable prebuild pex files will be available on versioned github releases.
+In future, readily-downloadable prebuilt pex files will be available on versioned github releases.
 
 #### 2. Grab a `Dockerfile`
 
@@ -120,7 +121,7 @@ The vagrant virtual environment provided will launch a VM will the following com
 
 ### 1. Start the VM
 
-To use the Vagrant box, run `vagrant box add debian-73-x64-virtualbox-nocm http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box` then `vagrant up` to set everything up.
+To use the Vagrant box, run `vagrant up` to set everything up. This will download a Debian 8 virtualmachine and install all the required processes/dependencies.
 
 ### 2. Test Mesos
 
@@ -128,7 +129,7 @@ The VM runs on a static IP `192.168.33.50` so before proceeding it's best to che
 
 ### 3. Build the executor
 
-To build the Portainer executor, simply run `bin/build-executor`.
+To build the Portainer executor, simply run `bin/build-executor` from the portainer root directory (`/opt/portainer`).
 
 _Note: If you've got a dirty git tree, you'll need to set the `FORCE=1` environment variable._
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ CODENAME=$(lsb_release -cs)
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | \
   sudo tee /etc/apt/sources.list.d/mesosphere.list
 sudo apt-get -y update
-sudo apt-get -y install mesos=0.24.2-2.0.17.debian81
+sudo apt-get -y install mesos=1.1.0-2.0.107.debian81
 sudo bash -c "echo 192.168.33.50 > /etc/mesos-master/ip"
 sudo bash -c "echo 192.168.33.50 > /etc/mesos-slave/ip"
 sudo bash -c "echo docker,mesos > /etc/mesos-slave/containerizers"
@@ -48,6 +48,7 @@ sudo service mesos-slave start
 
 # Install portainer dependencies
 sudo apt-get install -y python-setuptools
+sudo apt-get install -y python-dev
 sudo easy_install pip
 sudo pip install virtualenv
 SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,9 @@ sudo bash -c "echo 192.168.33.50 > /etc/mesos-slave/ip"
 sudo bash -c "echo docker,mesos > /etc/mesos-slave/containerizers"
 sudo bash -c "echo /usr/bin/docker-1.7.0 > /etc/mesos-slave/docker"
 
+# add local user as user on VM
+adduser $1
+
 # Start a bunch of services
 sudo service zookeeper restart
 sleep 5
@@ -70,5 +73,5 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :inline => "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/Europe/London /etc/localtime", run: "always"
 
   # Install all the things!
-  config.vm.provision "shell", inline: $docker_setup
+  config.vm.provision "shell", inline: $docker_setup, args: ENV['USER']
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ sudo chmod +x /usr/bin/docker-1.7.0
 
 # Set up the docker registry
 sudo mkdir -p /registry
-sudo docker create -p 5000:5000 -v /registry:/tmp/registry-dev --name=registry registry:0.9.1
+sudo docker create -p 5000:5000 -v /registry:/tmp/registry-dev --name=registry registry:2
 (sudo docker start registry || true)
 
 # Start mesos

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,6 +66,9 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
+  # ensure VM clock stays in sync with correct time zone
+  config.vm.provision :shell, :inline => "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/Europe/London /etc/localtime", run: "always"
+
   # Install all the things!
   config.vm.provision "shell", inline: $docker_setup
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ SCRIPT
 Vagrant.configure("2") do |config|
 
   # Use the same base box as vagrant-web
-  config.vm.box = "debian-73-x64-virtualbox-nocm"
+  config.vm.box = "puppetlabs/debian-8.2-64-nocm"
 
   config.vm.synced_folder "./", "/opt/portainer"
   config.vm.network :private_network, ip: "192.168.33.50"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure("2") do |config|
 
   # Configure the VM with 1024Mb of RAM and 2 CPUs
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,6 @@ sleep 5
 (sudo service mesos-slave stop || true)
 
 # Install Docker
-sudo bash -c 'echo "deb http://http.debian.net/debian wheezy-backports main" > /etc/apt/sources.list.d/backports.list'
-sudo apt-get install -y linux-image-amd64
 curl -sSL https://get.docker.com/ | sh
 sudo usermod -a -G docker vagrant
 
@@ -63,7 +61,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "./", "/opt/portainer"
   config.vm.network :private_network, ip: "192.168.33.50"
 
-  # Configure the VM with 1024Mb of RAM and 2 CPUs
+  # Configure the VM with 2048Mb of RAM and 2 CPUs
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "2048"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ CODENAME=$(lsb_release -cs)
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | \
   sudo tee /etc/apt/sources.list.d/mesosphere.list
 sudo apt-get -y update
-sudo apt-get -y install mesos
+sudo apt-get -y install mesos=0.24.2-2.0.17.debian81
 sudo bash -c "echo 192.168.33.50 > /etc/mesos-master/ip"
 sudo bash -c "echo 192.168.33.50 > /etc/mesos-slave/ip"
 sudo bash -c "echo docker,mesos > /etc/mesos-slave/containerizers"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,6 @@ SCRIPT
 
 Vagrant.configure("2") do |config|
 
-  # Use the same base box as vagrant-web
   config.vm.box = "puppetlabs/debian-8.2-64-nocm"
 
   config.vm.synced_folder "./", "/opt/portainer"

--- a/bin/build-executor
+++ b/bin/build-executor
@@ -42,7 +42,7 @@ pushd $TMP_DIR > /dev/null
 
     echo "Fetching dependencies (fresh) to wheelhouse"
     # Use wheel to download, so that we get git-urls and non-pypi releases, all consistently bundled as wheels for pex
-    # to then load. Mo need to fetch dependencies, as pex will do it anyway (and do it better it seems)
+    # to then load. No need to fetch dependencies, as pex will do it anyway (and do it better it seems)
     mkdir wheelhouse
 
     pip wheel -q --no-deps -r $SOURCE_DIR/requirements.pip -w wheelhouse
@@ -54,7 +54,7 @@ pushd $TMP_DIR > /dev/null
     echo "Building pex"
     # Then feed them all to pex, using the wheelhouse as the cache dir. Provide a cache TTL to trick pex into using the
     # .whl files even though the req list entries are inexact
-    pex $reqs --wheel --repo=wheelhouse --cache-dir=wheelhouse --cache-ttl=9999 -i file://$SOURCE_DIR  -e portainer.app -o ./bin/portainer
+    pex $SOURCE_DIR $reqs --wheel --cache-dir=wheelhouse --cache-ttl=9999 -e portainer.app -o ./bin/portainer
 
     # if there's anything that looks like a non-pure-python wheel being used, mark the filename as platform-specific
     # check for wheels with names that aren't "..-py2..", "..-py2.py3.." etc -- ones with c deps for example are named "..-cp27.."

--- a/bin/build-executor
+++ b/bin/build-executor
@@ -43,20 +43,22 @@ pushd $TMP_DIR > /dev/null
     echo "Fetching dependencies (fresh) to wheelhouse"
     # Use wheel to download, so that we get git-urls and non-pypi releases, all consistently bundled as wheels for pex
     # to then load. Mo need to fetch dependencies, as pex will do it anyway (and do it better it seems)
-    pip wheel -q --no-deps -r $SOURCE_DIR/requirements.pip
+    mkdir wheelhouse
+
+    pip wheel -q --no-deps -r $SOURCE_DIR/requirements.pip -w wheelhouse
 
     # Gather up all requirements as cli "-r" args to pex. Because we have git urls, we have to provide them all
     # 'inexact' as bare names, as we don't know the versions in advance
-    reqs=$(ls wheelhouse | sed -n 's/^\([^-]*\)-.*$/\1/p' | grep -v pex | awk '$0="-r "$0')
+    reqs=$(ls wheelhouse | sed -n 's/^\([^-]*\)-.*$/\1/p' | grep -v pex | awk '$0=" "$0')
 
     echo "Building pex"
     # Then feed them all to pex, using the wheelhouse as the cache dir. Provide a cache TTL to trick pex into using the
     # .whl files even though the req list entries are inexact
-    pex --wheel --repo wheelhouse --cache-dir wheelhouse --cache-ttl=9999 $reqs -s $SOURCE_DIR  -e portainer.app -o ./bin/portainer
+    pex $reqs --wheel --repo=wheelhouse --cache-dir=wheelhouse --cache-ttl=9999 -i file://$SOURCE_DIR  -e portainer.app -o ./bin/portainer
 
     # if there's anything that looks like a non-pure-python wheel being used, mark the filename as platform-specific
     # check for wheels with names that aren't "..-py2..", "..-py2.py3.." etc -- ones with c deps for example are named "..-cp27.."
-    if $(ls | grep -qv '^.*-.*-py\d'); then
+    if $(ls wheelhouse | grep -qv '^.*-.*-py\d'); then
         PLATFORM=$(python -c 'import pkg_resources; print pkg_resources.get_build_platform()')
         TAR_NAME="${TAR_NAME}.${PLATFORM}"
     fi

--- a/example/tree/a/Dockerfile
+++ b/example/tree/a/Dockerfile
@@ -1,6 +1,6 @@
 
-FROM ubuntu:12.04
-MAINTAINER Tom Arnfeld <tom@duedil.com>
+FROM ubuntu:14.04
+MAINTAINER Oli Hall <oliver.hall@duedil.com>
 
 REPOSITORY portainer/tree-a
 

--- a/example/tree/b/Dockerfile
+++ b/example/tree/b/Dockerfile
@@ -1,6 +1,6 @@
 
 FROM portainer/tree-a
-MAINTAINER Tom Arnfeld <tom@duedil.com>
+MAINTAINER Oli Hall <oliver.hall@duedil.com>
 
 REPOSITORY portainer/tree-b
 

--- a/portainer/app/__main__.py
+++ b/portainer/app/__main__.py
@@ -35,8 +35,7 @@ def main(argv):
     formatter = logging.Formatter(fmt="%(asctime)s[%(name)s] %(message)s")
     handler.setFormatter(formatter)
 
-    for logger in ("portainer.build", "portainer.scheduler", "portainer.executor", "pesos",
-                   "compactor", "tornado"):
+    for logger in ("portainer.build", "portainer.scheduler", "portainer.executor", "pesos", "compactor", "tornado"):
         logger = logging.getLogger(logger)
         logger.propagate = False
         logger.addHandler(handler)

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -65,9 +65,8 @@ def main(args):
         'name': 'portainer'
     }
 
-    # TODO role not supported by pymesos
-    # if args.framework_role:
-    #     framework.role = args.framework_role
+    if args.framework_role:
+        framework['role'] = args.framework_role
 
     if args.framework_id:
         framework['id'] = {

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -9,8 +9,10 @@ import time
 
 from portainer.app import subcommand
 from portainer.app.scheduler import Scheduler
+from portainer.util.parser import parse_dockerfile
 
 from pymesos import MesosSchedulerDriver
+
 
 logger = logging.getLogger("portainer.build")
 
@@ -59,10 +61,13 @@ def main(args):
         logger.error("The --repository argument cannot be used when building multiple images")
         sys.exit(1)
 
+    # TODO eliminate duplication of dockerfile parsing
+    dockerfiles = [parse_dockerfile(d, registry=args.pull_registry) for d in args.dockerfile]
+
     # Launch the mesos framework
     framework = {
         'user': getpass.getuser(),
-        'name': 'portainer'
+        'name': 'Portainer: building %s' % ', '.join([d.get("REPOSITORY").next()[0] for d in dockerfiles])
     }
 
     if args.framework_role:

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -61,7 +61,7 @@ def main(args):
 
     # Launch the mesos framework
     framework = mesos_pb2.FrameworkInfo()
-    framework.user = getpass.getuser()
+    framework.user = 'root' #getpass.getuser()
     framework.name = "portainer"
 
     if args.framework_role:

--- a/portainer/app/build.py
+++ b/portainer/app/build.py
@@ -1,4 +1,4 @@
-"""The entrypoint to the portainer app. Spins up the a scheduler instance and
+"""The entrypoint to the portainer app. Spins up a scheduler instance and
 waits for the result."""
 
 import getpass

--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -72,7 +72,7 @@ class Executor(pymesos.Executor):
             # Use the `wrapdocker` script included in our docker image
             proc = subprocess.Popen(["/usr/local/bin/wrapdocker"], env=env)
 
-            self.docker = docker.Client()
+            self.docker = docker.APIClient()
             while True:
                 try:
                     self.docker.ping()
@@ -90,7 +90,7 @@ class Executor(pymesos.Executor):
             daemon_thread.setDaemon(True)
             daemon_thread.start()
         else:
-            self.docker = docker.Client(build_task.daemon.docker_host)
+            self.docker = docker.APIClient(base_url=build_task.daemon.docker_host)
             self.docker_daemon_up = True
 
     def reregistered(self, driver, slaveInfo):

--- a/portainer/app/executor.py
+++ b/portainer/app/executor.py
@@ -24,7 +24,7 @@ from portainer.proto import portainer_pb2
 logger = logging.getLogger("portainer.executor")
 
 
-@subcommand("build-executor")
+@subcommand("run-executor")
 def main(args):
     driver = pymesos.MesosExecutorDriver(Executor())
 

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -444,30 +444,34 @@ class Scheduler(pymesos.Scheduler):
         if self.verbose:
             args.append("--verbose")
 
-        task['executor'] = {}
-        task['executor']['executor_id'] = {
-            'value': build_task.task_id
-        }
-        task['executor']['command'] = {
-            'value': "${MESOS_SANDBOX:-${MESOS_DIRECTORY}}/%s/bin/portainer %s build-executor"
-                     % (os.path.basename(self.executor_uri).rstrip(".tar.gz"), " ".join(args))
+        task['executor'] = {
+            'executor_id': {
+                'value': build_task.task_id
+            },
+            'command': {
+                'value': "${MESOS_SANDBOX:-${MESOS_DIRECTORY}}/%s/bin/portainer %s build-executor"
+                         % (os.path.basename(self.executor_uri).rstrip(".tar.gz"), " ".join(args))
+            }
         }
 
         if self.container_image:
-            # TODO This const is a guess currently
-            task['executor']['container'] = {}
-            task['executor']['container']['type'] = 'DOCKER'
-            task['executor']['container']['docker'] = {}
-            task['executor']['container']['docker']['image'] = self.container_image
-            task['executor']['container']['docker']['privileged'] = True
+            task['executor']['container'] = {
+                'type': 'DOCKER',
+                'docker': {
+                    'image': self.container_image,
+                    'privileged': True
+                }
+            }
 
         task['executor']['name'] = "build"
         task['executor']['source'] = "build %s" % (task['name'])
 
         # Configure the mesos executor with the portainer executor uri
-        task['executor']['command']['uris'] = [{
-            'value': self.executor_uri
-        }]
+        task['executor']['command']['uris'] = [
+            {
+                'value': self.executor_uri
+            }
+        ]
 
         if build_task.context:
             # Add the docker context

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -449,7 +449,7 @@ class Scheduler(pymesos.Scheduler):
                 'value': build_task.task_id
             },
             'command': {
-                'value': "${MESOS_SANDBOX:-${MESOS_DIRECTORY}}/%s/bin/portainer %s build-executor"
+                'value': "${MESOS_SANDBOX:-${MESOS_DIRECTORY}}/%s/bin/portainer %s run-executor"
                          % (os.path.basename(self.executor_uri).rstrip(".tar.gz"), " ".join(args))
             }
         }

--- a/portainer/app/scheduler.py
+++ b/portainer/app/scheduler.py
@@ -183,7 +183,7 @@ class Scheduler(pymesos.Scheduler):
             if len(registry) > 1:
                 build_task.image.registry.port = int(registry[1])
         except ValueError:
-            raise ValueError("Failed to parse REGISTRY in %s", path)
+            raise ValueError("Failed to parse REGISTRY in %s" % path)
 
         # Add any tags
         build_task.image.tag.extend(tags)

--- a/requirements.pexbuild.txt
+++ b/requirements.pexbuild.txt
@@ -1,4 +1,4 @@
-pex==0.8.6
-pip==1.5.2
-setuptools==7
+pex==1.1.19
+pip==9.0.1
+setuptools==30.4.0
 wheel

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 git+git://github.com/duedil-ltd/pyfilesystem.git@2b58f1359f50ecaf9ffea1e9ab3a88afb9f84d5e#egg=fs
 trollius==0.4
 protobuf>=2.6.1,<2.7
-docker-py==0.4.0
+docker==2.0.2
 boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4

--- a/requirements.pip
+++ b/requirements.pip
@@ -7,3 +7,4 @@ boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
 mesos.interface==0.23.1
+pymesos==0.2.9

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,5 @@
 git+git://github.com/tarnfeld/pesos.git@d489a976cd9aaf9012e03888d7bfb44b903977c6#egg=pesos
-git+git://github.com/duedil-ltd/pyfilesystem.git@f952ec334e074d56f187dd61a3932d7b884dbdde#egg=fs
+git+git://github.com/duedil-ltd/pyfilesystem.git@2b58f1359f50ecaf9ffea1e9ab3a88afb9f84d5e#egg=fs
 trollius==0.4
 protobuf>=2.6.1,<2.7
 docker-py==0.4.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -6,4 +6,4 @@ docker-py==0.4.0
 boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
-mesos.interface==0.21.1
+mesos.interface==0.23.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,3 @@
-git+git://github.com/oli-hall/pesos.git@05adcb0621b51e2734322b7d8e4bc4104ceaef35#egg=pesos
 git+git://github.com/duedil-ltd/pyfilesystem.git@2b58f1359f50ecaf9ffea1e9ab3a88afb9f84d5e#egg=fs
 trollius==0.4
 protobuf>=2.6.1,<2.7
@@ -6,5 +5,4 @@ docker-py==0.4.0
 boto==2.27.0
 progressbar==2.2
 pywebhdfs==0.2.4
-mesos.interface==0.23.1
 pymesos==0.2.9

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,4 @@
-git+git://github.com/tarnfeld/pesos.git@d489a976cd9aaf9012e03888d7bfb44b903977c6#egg=pesos
+git+git://github.com/oli-hall/pesos.git@05adcb0621b51e2734322b7d8e4bc4104ceaef35#egg=pesos
 git+git://github.com/duedil-ltd/pyfilesystem.git@2b58f1359f50ecaf9ffea1e9ab3a88afb9f84d5e#egg=fs
 trollius==0.4
 protobuf>=2.6.1,<2.7


### PR DESCRIPTION
JIRA: https://duedil.atlassian.net/browse/DD-13627

This updates Portainer to work with Mesos 1.1.0, and incorporates a couple of minor improvements (such as https://github.com/duedil-ltd/portainer/issues/10).

The main changes: the `pesos` python library has been removed in favour of `pymesos`, which uses the HTTP API used by Mesos from version 0.28.0 onwards. The changes here are mostly trivial (API calls take dictionaries rather than Mesos protobuf structures, changes in terminology from 'slave' to 'agent').

As part of the upgrade, PEX has also been upgraded, and the VM installation has been tweaked to install Docker registry 2 and Docker 1.10.3 (as per production), as well as now being based upon Debian 8. The memory allocated to the VM has also been increased, as portainer builds were causing the Mesos Master process in the VM to be terminated with the original 1024MB.